### PR TITLE
set scrollwheel to false on Map

### DIFF
--- a/resources/assets/js/components/HomeMap.vue
+++ b/resources/assets/js/components/HomeMap.vue
@@ -21,7 +21,7 @@
                 var mapOptions = {
                     zoom: 3,
                     center: new google.maps.LatLng(51.165691, 10.451526),
-
+                    scrollwheel: false
                 };
                 geomap = new google.maps.Map(document.querySelector('#map'), mapOptions);
                 this.createMap(geomap,'initialized');


### PR DESCRIPTION
I'd recommend this change so that one can scroll down the home page without accidentally wildly zooming the map each time.