### PR TITLE
Fix typo; use config value for app name

### DIFF
--- a/resources/views/emails/users/social_welcome_email.blade.php
+++ b/resources/views/emails/users/social_welcome_email.blade.php
@@ -1,4 +1,4 @@
-<h4>Welcome to PHPMap, {{ $user->username }}!</h4>
-<p>Thanks for siging up on PHPMap!</p>
+<h4>Welcome to {{ config('app.name') }}, {{ $user->username }}!</h4>
+<p>Thanks for signing up on {{ config('app.name') }}!</p>
 <p>Your temporary password is: <strong>{{ 'PHPMap_'.$user->username.'_TEMP' }}</strong></p>
 <p>To change your password, visit <a href="{{ url('/settings') }}">this URL</a>.</p>

--- a/resources/views/emails/users/welcome_email.blade.php
+++ b/resources/views/emails/users/welcome_email.blade.php
@@ -1,2 +1,2 @@
-<h4>Welcome to PHPMap, {{ $user->username }}!</h4>
-<p>Thanks for siging up on PHPMap!</p>
+<h4>Welcome to {{ config('app.name') }}, {{ $user->username }}!</h4>
+<p>Thanks for signing up on {{ config('app.name') }}!</p>


### PR DESCRIPTION
* Fix typo with ‘signing’.
* Use configuration value (`app.name`) in place of hard-coded application name.